### PR TITLE
Add Leagues

### DIFF
--- a/pysbr/config/brasileiroseriea.yaml
+++ b/pysbr/config/brasileiroseriea.yaml
@@ -1,0 +1,3 @@
+lid: 32
+name: Brasileiro Serie A
+abbreviation: BrasileiroSerieA

--- a/pysbr/config/eredivisie.yaml
+++ b/pysbr/config/eredivisie.yaml
@@ -1,0 +1,3 @@
+lid: 29
+name: Eredivisie
+abbreviation: Eredivisie

--- a/pysbr/config/leagueone.yaml
+++ b/pysbr/config/leagueone.yaml
@@ -1,0 +1,3 @@
+lid: 227
+name: League One
+abbreviation: LeagueOne

--- a/pysbr/config/ligue1.yaml
+++ b/pysbr/config/ligue1.yaml
@@ -1,0 +1,3 @@
+lid: 9
+name: Ligue 1
+abbreviation: Ligue1

--- a/pysbr/config/primeiraliga.yaml
+++ b/pysbr/config/primeiraliga.yaml
@@ -1,0 +1,3 @@
+lid: 33
+name: Primeira Liga
+abbreviation: PrimeiraLiga

--- a/pysbr/config/seriea.yaml
+++ b/pysbr/config/seriea.yaml
@@ -1,0 +1,3 @@
+lid: 10
+name: Serie A
+abbreviation: SerieA

--- a/pysbr/config/sport.py
+++ b/pysbr/config/sport.py
@@ -572,6 +572,12 @@ class Eredivisie(League):
 
     def __init__(self):
         super().__init__("soccer", "eredivisie")
+        
+class BrasileiroSerieA(League):
+    """Provides access to Brasileiro Serie A config files."""
+
+    def __init__(self):
+        super().__init__("soccer", "brasileiroseriea")
 
 
 class Bundesliga(League):

--- a/pysbr/config/sport.py
+++ b/pysbr/config/sport.py
@@ -567,6 +567,12 @@ class SerieA(League):
     def __init__(self):
         super().__init__("soccer", "seriea")
         
+class Ligue1(League):
+    """Provides access to Ligue 1 config files."""
+
+    def __init__(self):
+        super().__init__("soccer", "ligue1")
+        
 class Eredivisie(League):
     """Provides access to Eredivisie config files."""
 

--- a/pysbr/config/sport.py
+++ b/pysbr/config/sport.py
@@ -584,6 +584,12 @@ class BrasileiroSerieA(League):
 
     def __init__(self):
         super().__init__("soccer", "brasileiroseriea")
+        
+class LeagueOne(League):
+    """Provides access to League One config files."""
+
+    def __init__(self):
+        super().__init__("soccer", "leagueone")
 
 
 class Bundesliga(League):

--- a/pysbr/config/sport.py
+++ b/pysbr/config/sport.py
@@ -566,6 +566,12 @@ class SerieA(League):
 
     def __init__(self):
         super().__init__("soccer", "seriea")
+        
+class Eredivisie(League):
+    """Provides access to Eredivisie config files."""
+
+    def __init__(self):
+        super().__init__("soccer", "eredivisie")
 
 
 class Bundesliga(League):

--- a/pysbr/config/sport.py
+++ b/pysbr/config/sport.py
@@ -560,6 +560,12 @@ class PrimeiraLiga(League):
 
     def __init__(self):
         super().__init__("soccer", "primeiraliga")
+        
+class SerieA(League):
+    """Provides access to Serie A config files."""
+
+    def __init__(self):
+        super().__init__("soccer", "seriea")
 
 
 class Bundesliga(League):

--- a/pysbr/config/sport.py
+++ b/pysbr/config/sport.py
@@ -554,6 +554,12 @@ class LaLiga(League):
 
     def __init__(self):
         super().__init__("soccer", "laliga")
+        
+class PrimeiraLiga(League):
+    """Provides access to Primeira Liga config files."""
+
+    def __init__(self):
+        super().__init__("soccer", "primeiraliga")
 
 
 class Bundesliga(League):


### PR DESCRIPTION
Primeira Liga league added to conf. 
Serie A league added to conf(Italy).
Eredivisie  league added to conf.
Brazil Serie A league added to conf.
Ligue 1 league added to conf.
League One (EFL League One (English Soccer Second League)) added to conf.

Other leagues SBR does not seem to support are: 

Kontinental Hockey League,
Turkish Supir Lig (Turkish Soccer Premier League)